### PR TITLE
Update to Webpack 5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends":
   [
     "eslint:recommended",
-    "idiomatic",
     "plugin:jsdoc/recommended"
   ],
   "rules":

--- a/package.json
+++ b/package.json
@@ -33,18 +33,17 @@
   },
   "peerDependencies": {
     "gulp": "^4.0.0",
-    "webpack": "^4.0.0"
+    "webpack": "^5.28.0"
   },
   "devDependencies": {
     "ava": "^3.8.1",
     "eslint": "^6.8.0",
-    "eslint-config-idiomatic": "^4.0.0",
     "eslint-plugin-jsdoc": "^24.0.2",
     "gulp": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "vinyl-fs": "^3.0.3",
     "vinyl-named": "^1.1.0",
-    "webpack": "^4.43.0"
+    "webpack": "5.28.0"
   },
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-webpack-yawp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Yet another Webpack plugin (for Gulp)",
   "repository": "https://github.com/crisisinaptica/gulp-webpack-yawp",
   "author": "Sergio Jiménez Herena",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "gulp": "^4.0.0",
-    "webpack": "^5.28.0"
+    "webpack": "^5.0.0"
   },
   "devDependencies": {
     "ava": "^3.8.1",

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ const
 
 
 test.before( 'cleanup', () => {
-  fs.rmdirSync( 'test/out', { recursive: true });
+  fs.rmSync( 'test/out', { recursive: true, force: true });
 });
 
 
@@ -161,7 +161,7 @@ test.cb( 'compile source maps', t => {
     .pipe( gulpWebpack({
       wpConfig: {
         mode: 'development',
-        devtool: 'sourcemap',
+        devtool: 'source-map',
       },
       logMode: 'silent'
     }))


### PR DESCRIPTION
Changes:
- Removed Idiomatic (`eslint-config-idiomatic` and its line from the `.eslint` file)
- Update deprecated `rmdir` in favour of `rm`
- Update test WP configuration string for source maps